### PR TITLE
SF4 compatibility

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,6 +9,6 @@
     </parameters>
 
     <services>
-        <service id="gitlab_api" alias="zeichen32_gitlabapi.client.default" />
+        <service id="gitlab_api" alias="zeichen32_gitlabapi.client.default" public="true" />
     </services>
 </container>


### PR DESCRIPTION
With Symfony 4 to use service in controller by example, this one need to be set to `public`.
Updating service `gitlab_api` to public visibility.