### PR TITLE
Update composer requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 branches:
   only:
@@ -10,12 +11,14 @@ branches:
 
 matrix:
   include:
-    - php: 7.2
-      env: SYMFONY_VERSION='3.3.*'
-    - php: 7.2
+    - php: 7.4
       env: SYMFONY_VERSION='3.4.*'
-    - php: 7.2
-      env: SYMFONY_VERSION='4.0.*'
+    - php: 7.4
+      env: SYMFONY_VERSION='4.3.*'
+    - php: 7.4
+      env: SYMFONY_VERSION='4.4.*'
+    - php: 7.4
+      env: SYMFONY_VERSION='5.0.*'
   fast_finish: true
   allow_failures:
     - php: nightly
@@ -25,4 +28,4 @@ before_script:
   - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
   - composer update --prefer-source
 
-script: phpunit
+script: vendor/bin/phpunit

--- a/Tests/DependencyInjection/Zeichen32GitLabApiExtensionTest.php
+++ b/Tests/DependencyInjection/Zeichen32GitLabApiExtensionTest.php
@@ -10,7 +10,9 @@
 
 namespace Zeichen32\GitLabApiBundle\Tests\DependencyInjection;
 
+use Http\Client\HttpClient;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Zeichen32\GitLabApiBundle\DependencyInjection\Zeichen32GitLabApiExtension;
@@ -27,13 +29,13 @@ class Zeichen32GitLabApiExtensionTest extends TestCase {
     private $extension;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = new ContainerBuilder();
         $this->extension = new Zeichen32GitLabApiExtension();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->container, $this->extension);
     }
@@ -64,10 +66,9 @@ class Zeichen32GitLabApiExtensionTest extends TestCase {
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testWrongAuthMethod() {
+        $this->expectException(InvalidConfigurationException::class);
+
         $config = array(
             'zeichen32_git_lab_api' => array('clients' => array(
                 'firstclient' => array(
@@ -130,8 +131,9 @@ class Zeichen32GitLabApiExtensionTest extends TestCase {
             )),
         );
 
-        $httpClient = $this->createMock('Http\Client\HttpClient');
-        $this->container->setDefinition('http.client', new Definition($httpClient));
+        $httpClient = $this->createMock(HttpClient::class);
+        $this->container->setDefinition('http.client', new Definition(HttpClient::class));
+        $this->container->set('http.client', $httpClient);
 
         $this->extension->load($config, $this->container);
 
@@ -139,12 +141,12 @@ class Zeichen32GitLabApiExtensionTest extends TestCase {
         $secondClient = $this->container->get('zeichen32_gitlabapi.client.secondclient');
 
         $this->assertInstanceOf(
-            'Http\Client\HttpClient',
+            HttpClient::class,
             $firstClient->getHttpClient()
         );
 
         $this->assertInstanceOf(
-            'Http\Client\HttpClient',
+            HttpClient::class,
             $secondClient->getHttpClient()
         );
     }

--- a/Tests/Zeichen32GitLabApiBundleTest.php
+++ b/Tests/Zeichen32GitLabApiBundleTest.php
@@ -8,7 +8,7 @@
  * Time: 14:15
  */
 
-namespace Zeichen32\GitLabApiBundle;
+namespace Zeichen32\GitLabApiBundle\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Zeichen32\GitLabApiBundle\Zeichen32GitLabApiBundle;

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
-        "symfony/framework-bundle": "^2.6|^3.0|^4.0|^5.0",
+        "php": "^7.2",
+        "symfony/framework-bundle": "^3.4|^4.3|^5.0",
         "m4tthumphrey/php-gitlab-api": "^9"
     },
     "require-dev" : {
         "php-http/message": "^1.6",
         "php-http/guzzle6-adapter": "^1.1",
-        "phpunit/phpunit": "~6.5"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-0": { "Zeichen32\\GitLabApiBundle": "" }


### PR DESCRIPTION
- Use phpunit 8
- Update unit tests
- Only add supported symfony versions to composer.json
- Only add supported php version to travis.yaml
- Fix the psr_0 path for `Tests/Zeichen32GitlabApiBundleTest.php`. Composer 2.0 will not autoload this file because it was incompatible with psr_0