### PR TITLE
Add missing return type

### DIFF
--- a/DependencyInjection/Zeichen32GitLabApiExtension.php
+++ b/DependencyInjection/Zeichen32GitLabApiExtension.php
@@ -28,7 +28,7 @@ class Zeichen32GitLabApiExtension extends Extension
     /**
      * {@inheritDoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);


### PR DESCRIPTION
To fix deprecation:

```
Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Zeichen32\GitLabApiBundle\DependencyInjection\Zeichen32GitLabApiExtension" now to avoid errors or add an explicit @return annotation to suppress this message.
```