### PR TITLE
Fix namespace import for DependencyInjection extension

### DIFF
--- a/DependencyInjection/Zeichen32GitLabApiExtension.php
+++ b/DependencyInjection/Zeichen32GitLabApiExtension.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**


### PR DESCRIPTION
Do not use deprecated `Symfony\Component\HttpKernel\DependencyInjection\Extension` (since Symfony `7.1`) anymore.